### PR TITLE
Add --ignore=undefinedtarget

### DIFF
--- a/scripts/entrypoint.py
+++ b/scripts/entrypoint.py
@@ -289,6 +289,7 @@ class DebRepositoryBuilder:
                     "-b",
                     self.apt_dir,
                     "--keepunusednewfiles",
+                    "--ignore=undefinedtarget",
                     "--export=silent-never",
                     "includedeb",
                     self.config["deb_file_version"],


### PR DESCRIPTION
This will allow the repo to have packages for specific versions only (i.e. only have backports for jammy be available for jammy)

If this is not a welcome change, an option to pass any args to the `reprepro` command from the action step would be nice.

P.S: Thanks for the work you do on this fork.
P.P.S: Perhaps you should enable issues